### PR TITLE
Fixes the error from cof_selection function

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,1 @@
+"%||%" <- function(a, b) if (!is.null(a)) a else b


### PR DESCRIPTION
Error was deviance(x) %||% extractAIC(x, k = 0)[2L] :  could not find function "%||%". It turns out cof_selection function uses step function that uses %||% function that is not part of base R.